### PR TITLE
Add permissions & fix grammer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /.idea/
 /.gradle/
+.gradle/
+build/

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = 'com.maximde'
-version = '1.3.0'
+version = '1.4.0'
 
 repositories {
     mavenCentral()

--- a/src/main/java/com/maximde/entitysize/commands/EntitySizeCommand.java
+++ b/src/main/java/com/maximde/entitysize/commands/EntitySizeCommand.java
@@ -34,6 +34,10 @@ public class EntitySizeCommand implements CommandExecutor, TabCompleter {
 
         switch (args[0].toLowerCase()) {
             case "player" -> {
+                if(!sender.hasPermission(entitySize.getPermission("player"))) {
+                    sender.sendMessage(entitySize.getPrimaryColor() + "You don't have the permission to execute this subcommand!");
+                    return false;
+                }
                 if(args.length < 3) return sendCommands(sender);
                 Player target = Bukkit.getPlayer(args[1]);
                 if(target == null || !target.isOnline()) {
@@ -55,27 +59,47 @@ public class EntitySizeCommand implements CommandExecutor, TabCompleter {
             }
 
             case "entity" -> {
+                if(!sender.hasPermission(entitySize.getPermission("entity"))) {
+                    sender.sendMessage(entitySize.getPrimaryColor() + "You don't have the permission to execute this command!");
+                    return false;
+                }
                 if(args.length < 2) return sendCommands(sender);
-                handleEntityArg(sender, args);
+                boolean success = handleEntityArg(sender, args);
+                if(!success) return false;
             }
 
             case "reload" -> {
+                if(!sender.hasPermission(entitySize.getPermission("reload"))) {
+                    sender.sendMessage(entitySize.getPrimaryColor() + "You don't have the permission to execute this command!");
+                    return false;
+                }
                 entitySize.getConfiguration().reload();
                 sender.sendMessage(entitySize.getPrimaryColor() + "Config reloaded!");
             }
 
             case "reset" -> {
+                if(!sender.hasPermission(entitySize.getPermission("reset"))) {
+                    sender.sendMessage(entitySize.getPrimaryColor() + "You don't have the permission to execute this command!");
+                    return false;
+                }
                 if(args.length == 1) {
                     entitySize.getConfiguration().reload();
                     entitySize.resetSize((Player)sender);
                     sender.sendMessage(entitySize.getPrimaryColor() + "Size resetet!");
                     return false;
                 } else if (args.length == 2) {
-
                     if(args[1].equalsIgnoreCase("@a")) {
+                        if(!sender.hasPermission(entitySize.getPermission("reset.all"))) {
+                            sender.sendMessage(entitySize.getPrimaryColor() + "You don't have the permission to execute this command!");
+                            return false;
+                        }
                         Bukkit.getOnlinePlayers().forEach(entitySize::resetSize);
                         sender.sendMessage(entitySize.getPrimaryColor() + "Size resetet for " + Bukkit.getOnlinePlayers().size()+" players!");
                         return true;
+                    }
+                    if(!sender.hasPermission(entitySize.getPermission("reset.player"))) {
+                        sender.sendMessage(entitySize.getPrimaryColor() + "You don't have the permission to execute this command!");
+                        return false;
                     }
 
                     Player target = Bukkit.getPlayer(args[1]);
@@ -93,6 +117,10 @@ public class EntitySizeCommand implements CommandExecutor, TabCompleter {
 
             default -> {
                 try {
+                    if(!sender.hasPermission(entitySize.getPermission("self"))) {
+                        sender.sendMessage(entitySize.getPrimaryColor() + "You don't have the permission to execute this command!");
+                        return false;
+                    }
                     double size = Double.parseDouble(args[0]);
                     Player player = (Player) sender;
                     entitySize.setSize(player, size);
@@ -106,78 +134,104 @@ public class EntitySizeCommand implements CommandExecutor, TabCompleter {
         return false;
     }
 
-    private void handleEntityArg(CommandSender sender, String[] args) {
+    private boolean handleEntityArg(CommandSender sender, String[] args) {
         if (args.length < 3) {
             sendCommands(sender);
-            return;
+            return false;
         }
+
 
         switch (args[1].toLowerCase()) {
             case "looking" -> {
+                if(!sender.hasPermission(entitySize.getPermission("entity.looking"))) {
+                    sender.sendMessage(entitySize.getPrimaryColor() + "You don't have the permission to execute this command!");
+                    return false;
+                }
 
                 double size = Double.parseDouble(args[2]);
 
                 if(!(sender instanceof Player player)) {
                     sender.sendMessage(entitySize.getPrimaryColor() + "You can only execute this command as a player!");
-                    return;
+                    return false;
                 }
 
                 Optional<LivingEntity> optionalEntity = entitySize.getEntity(player, 30);
 
                 if(optionalEntity.isEmpty()) {
                     player.sendMessage(entitySize.getPrimaryColor() + "No entity found!");
-                    return;
+                    return false;
                 }
 
                 handleEntities(entity -> optionalEntity.get() == entity, size);
                 sender.sendMessage(entitySize.getPrimaryColor() + "Success!");
+                return true;
             }
             case "tag" -> {
+                if(!sender.hasPermission(entitySize.getPermission("entity.tag"))) {
+                    sender.sendMessage(entitySize.getPrimaryColor() + "You don't have the permission to execute this command!");
+                    return false;
+                }
                 if (args.length < 4) {
                     sendCommands(sender);
-                    return;
+                    return false;
                 }
                 String tag = args[2];
                 double size = Double.parseDouble(args[3]);
                 handleEntities(entity -> entity.getScoreboardTags().contains(tag), size);
                 sender.sendMessage(entitySize.getPrimaryColor() + "Success!");
+                return true;
             }
             case "name" -> {
+                if(!sender.hasPermission(entitySize.getPermission("entity.name"))) {
+                    sender.sendMessage(entitySize.getPrimaryColor() + "You don't have the permission to execute this command!");
+                    return false;
+                }
                 if (args.length < 4) {
                     sendCommands(sender);
-                    return;
+                    return false;
                 }
                 String name = args[2];
                 double size = Double.parseDouble(args[3]);
                 handleEntities(entity -> (entity.getCustomName() != null && entity.getCustomName().equalsIgnoreCase(name)) || entity.getName().equalsIgnoreCase(name), size);
                 sender.sendMessage(entitySize.getPrimaryColor() + "Success!");
+                return true;
             }
             case "uuid" -> {
+                if(!sender.hasPermission(entitySize.getPermission("entity.uuid"))) {
+                    sender.sendMessage(entitySize.getPrimaryColor() + "You don't have the permission to execute this command!");
+                    return false;
+                }
                 if (args.length < 4) {
                     sendCommands(sender);
-                    return;
+                    return false;
                 }
                 UUID uuid = UUID.fromString(args[2]);
                 double size = Double.parseDouble(args[3]);
                 handleEntities(entity -> entity.getUniqueId().equals(uuid), size);
                 sender.sendMessage(entitySize.getPrimaryColor() + "Success!");
+                return true;
             }
             case "range" -> {
+                if(!sender.hasPermission(entitySize.getPermission("entity.range"))) {
+                    sender.sendMessage(entitySize.getPrimaryColor() + "You don't have the permission to execute this command!");
+                    return false;
+                }
                 if (args.length < 4) {
                     sendCommands(sender);
-                    return;
+                    return false;
                 }
                 if(!(sender instanceof Player player)) {
                     sender.sendMessage(entitySize.getPrimaryColor() + "You can only execute this command as a player!");
-                    return;
+                    return false;
                 }
 
                 double range = Double.parseDouble(args[2]);
                 double size = Double.parseDouble(args[3]);
                 handleEntities(entity -> isWithinRange(entity, player, range), size);
                 sender.sendMessage(entitySize.getPrimaryColor() + "Success!");
+                return true;
             }
-            default -> sendCommands(sender);
+            default -> {sendCommands(sender); return false;}
         }
     }
 
@@ -196,6 +250,15 @@ public class EntitySizeCommand implements CommandExecutor, TabCompleter {
     }
 
     private boolean sendCommands(CommandSender sender) {
+        StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append(entitySize.getPrimaryColor());
+        if (sender.hasPermission("entitysize.player")) {
+            stringBuilder.append("/entitysize player <player> <size>\n");
+        }
+        if (sender.hasPermission("entitysize.entity.looking")) {
+            stringBuilder.append("/entitysize entity looking <size>\n");
+
+        }
         sender.sendMessage(entitySize.getPrimaryColor() +
                 "/entitysize reload (Reload config)\n" +
                 "/entitysize reset <optional player / @a> (Reset size to default)\n" +
@@ -222,25 +285,35 @@ public class EntitySizeCommand implements CommandExecutor, TabCompleter {
 
 
         if (args.length == 1) {
-            commands.addAll(Arrays.asList("<size>", "reload", "player", "entity", "reset"));
+            if (sender.hasPermission(entitySize.getPermission("player"))) commands.add("player");
+            if (sender.hasPermission(entitySize.getPermission("entity"))) commands.add("entity");
+            if (sender.hasPermission(entitySize.getPermission("reload"))) commands.add("reload");
+            if (sender.hasPermission(entitySize.getPermission("reset"))) commands.add("reset");
+            if (sender.hasPermission(entitySize.getPermission("self"))) commands.add("<size>");
+
             StringUtil.copyPartialMatches(args[0], commands, completions);
         }
 
         if (args.length == 2) {
-            if(args[0].equalsIgnoreCase("player")) {
+            if(args[0].equalsIgnoreCase("player")&&sender.hasPermission(entitySize.getPermission("player"))) {
                 Bukkit.getOnlinePlayers().forEach(player -> {
                     commands.add(player.getName());
                 });
             }
-            if(args[0].equalsIgnoreCase("entity")) {
-                commands.addAll(Arrays.asList("looking", "tag", "name", "range"));
+            if(args[0].equalsIgnoreCase("entity")&&sender.hasPermission(entitySize.getPermission("entity"))) {
+                if (sender.hasPermission(entitySize.getPermission("entity.looking"))) commands.add("looking");
+                if (sender.hasPermission(entitySize.getPermission("entity.tag"))) commands.add("tag");
+                if (sender.hasPermission(entitySize.getPermission("entity.name"))) commands.add("name");
+                if (sender.hasPermission(entitySize.getPermission("entity.uuid"))) commands.add("uuid");
+                if (sender.hasPermission(entitySize.getPermission("entity.range"))) commands.add("range");
+
             }
             StringUtil.copyPartialMatches(args[1], commands, completions);
         }
 
         if (args.length == 3) {
-            if(args[0].equalsIgnoreCase("player")) commands.add("<size>");
-            if(args[0].equalsIgnoreCase("entity")) {
+            if(args[0].equalsIgnoreCase("player")&&sender.hasPermission(entitySize.getPermission("player"))) commands.add("<size>");
+            if(args[0].equalsIgnoreCase("entity")&&sender.hasPermission(entitySize.getPermission("entity"))) {
                 switch (args[1].toLowerCase()) {
                     case "tag" -> commands.add("<tag>");
                     case "name" -> commands.add("<name>");

--- a/src/main/java/com/maximde/entitysize/commands/EntitySizeCommand.java
+++ b/src/main/java/com/maximde/entitysize/commands/EntitySizeCommand.java
@@ -85,7 +85,7 @@ public class EntitySizeCommand implements CommandExecutor, TabCompleter {
                 if(args.length == 1) {
                     entitySize.getConfiguration().reload();
                     entitySize.resetSize((Player)sender);
-                    sender.sendMessage(entitySize.getPrimaryColor() + "Size resetet!");
+                    sender.sendMessage(entitySize.getPrimaryColor() + "Size reset!");
                     return false;
                 } else if (args.length == 2) {
                     if(args[1].equalsIgnoreCase("@a")) {
@@ -94,7 +94,7 @@ public class EntitySizeCommand implements CommandExecutor, TabCompleter {
                             return false;
                         }
                         Bukkit.getOnlinePlayers().forEach(entitySize::resetSize);
-                        sender.sendMessage(entitySize.getPrimaryColor() + "Size resetet for " + Bukkit.getOnlinePlayers().size()+" players!");
+                        sender.sendMessage(entitySize.getPrimaryColor() + "Size reset for " + Bukkit.getOnlinePlayers().size()+" players!");
                         return true;
                     }
                     if(!sender.hasPermission(entitySize.getPermission("reset.player"))) {
@@ -108,7 +108,7 @@ public class EntitySizeCommand implements CommandExecutor, TabCompleter {
                         return false;
                     }
                     entitySize.resetSize(target);
-                    sender.sendMessage(entitySize.getPrimaryColor() + "Size resetet for " + target.getName());
+                    sender.sendMessage(entitySize.getPrimaryColor() + "Size reset for " + target.getName());
                     return true;
                 }
                 sendCommands(sender);

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -28,7 +28,7 @@ permissions:
     description: Allows the ability to reset any player
     default: false
   entitysize.reset.all:
-    description: Allows the ability to reset all players
+    description: Allows the ability to reset all players, using @a
     default: false
   entitysize.self:
     description: Allows the use of the self subcommand

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -7,3 +7,44 @@ api-version: '1.20'
 
 commands:
   entitysize:
+
+permissions:
+  entitysize.commands:
+    description: Allows the use of the entitysize command
+    default: true
+  entitysize.player:
+    description: Allows the use of the player subcommand
+    default: false
+  entitysize.entity:
+    description: Allows the use of the entity subcommand
+    default: false
+  entitysize.reload:
+    description: Allows the use of the reload subcommand
+    default: false
+  entitysize.reset:
+    description: Allows the use of the reset subcommand
+    default: true
+  entitysize.reset.player:
+    description: Allows the ability to reset any player
+    default: false
+  entitysize.reset.all:
+    description: Allows the ability to reset all players
+    default: false
+  entitysize.self:
+    description: Allows the use of the self subcommand
+    default: true
+  entitysize.entity.looking:
+    description: Allows selecting the entity being looked at
+    default: false
+  entitysize.entity.tag:
+    description: Allows selecting the entity by tag
+    default: false
+  entitysize.entity.name:
+    description: Allows selecting the entity by name
+    default: false
+  entitysize.entity.uuid:
+    description: Allows selecting the entity by uuid
+    default: false
+  entitysize.entity.range:
+    description: Allows selecting the entity by range
+    default: false


### PR DESCRIPTION
Ive made a few changes to make this work on a public server
- added permissions for all sub commands
this is currently very rudimentary, but it works (all parts of subcommands also need there parents ex. ``/entitysize entity looking`` needs `entitysize.entity.looking` AND ` entitysize.entity` AND `entitysize.commands`
- I fixed the spelling of resetet -> reset
